### PR TITLE
Feat: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,11 @@ FROM debian:buster-slim
 # Sets the email.
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 
+# Create an arg for the version.
+ARG version
+
 # Set version
-ENV VERSION 1.6.4
+ENV BUILDVER=$version
 
 # Install Java 11 (optionally will 16), and nano.
 RUN apt-get update && \
@@ -26,18 +29,18 @@ RUN apt-get update && \
 RUN useradd --no-log-init --shell /bin/false --no-create-home ducky-runner
 
 # Add Ducky-<release>.tar from the host working Directory to /opt/ in the container.
-COPY Ducky-$VERSION.tar /opt/
+COPY Ducky-$BUILDVER.tar /opt/
 
 # Decompress. Not using ADD because it's not .tar.gz
 RUN cd /opt/ && \
-    tar -xvf Ducky-$VERSION.tar
+    tar -xvf Ducky-$BUILDVER.tar
 
 # Set ownership.
-RUN chown -R ducky-runner:ducky-runner /opt/Ducky-$VERSION/
+RUN chown -R ducky-runner:ducky-runner /opt/Ducky-$BUILDVER/
 
 # Change user, set the working dir.
 USER ducky-runner
-WORKDIR /opt/Ducky-$VERSION/bin/
+WORKDIR /opt/Ducky-$BUILDVER/bin/
 
 # Enter the app. Not using ENTRYPOINT, as we don't use any startup flags rn...Or do we? :eyes:
 CMD ["./Ducky"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
+# Using Debian 10.
 FROM debian:buster
 
-MAINTAINER Simon <email.todo>
+# Sets the email.
+LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 
+# Install Java 11 (optionally will 16), and nano.
 RUN apt-get install -y wget apt-transport-https gnupg && \
     wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
     gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public && \
@@ -11,18 +14,26 @@ RUN apt-get install -y wget apt-transport-https gnupg && \
     echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
     apt-get update && \
     apt-get install adoptopenjdk-11-hotspot && \
+    apt-get install nano && \
     apt-get autoremove --purge -y && \
-    rm -rv /var/lib/apt/lists/* && \
-    useradd --no-log-init --shell /bin/false --no-create-home ducky-runner
+    rm -rv /var/lib/apt/lists/* 
 
+# Add the user we're going to run as.
+RUN useradd --no-log-init --shell /bin/false --no-create-home ducky-runner
+
+# Add Ducky-<release>.tar from the host working Directory to /opt/ in the container.
 ADD Ducky-*.tar /opt/
+
+# Set ownership, and unzip the files using Tar.
 RUN chown -R ducky-runner:ducky-runner /opt/Ducky-*.tar && \
     tar -xfz Ducky-*.tar > Ducky
 
+# Change user, set the working dir.
 USER ducky-runner
-WORKDIR /opt/Ducky/
+WORKDIR /opt/Ducky/bin/
 
-
+# Enter the app.
 ENTRYPOINT ["/bin/Ducky"]
+CMD ["./Ducky"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,12 @@ FROM debian:buster-slim
 # Sets the email.
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 
+# Set version
+ENV VERSION 1.6.3
+
 # Install Java 11 (optionally will 16), and nano.
-RUN apt-get install -y wget apt-transport-https gnupg && \
+RUN apt-get update && \
+    apt-get install -y wget apt-transport-https gnupg && \
     wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
     gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public && \
     gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg && \
@@ -13,27 +17,27 @@ RUN apt-get install -y wget apt-transport-https gnupg && \
     mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
     apt-get update && \
-    apt-get install adoptopenjdk-11-hotspot && \
-    apt-get install nano && \
+    apt-get install adoptopenjdk-11-hotspot -y && \
+    apt-get install nano -y && \
     apt-get autoremove --purge -y && \
-    rm -rv /var/lib/apt/lists/* 
+    rm -rv /var/lib/apt/lists/*
 
 # Add the user we're going to run as.
 RUN useradd --no-log-init --shell /bin/false --no-create-home ducky-runner
 
 # Add Ducky-<release>.tar from the host working Directory to /opt/ in the container.
-ADD Ducky-*.tar /opt/
+COPY Ducky-$VERSION.tar /opt/
 
-# Set ownership, and unzip the files using Tar.
-RUN chown -R ducky-runner:ducky-runner /opt/Ducky-*.tar && \
-    tar -xfz Ducky-*.tar > Ducky
+# Decompress. Not using ADD because it's not .tar.gz
+RUN cd /opt/ && \
+    tar -xvf Ducky-$VERSION.tar
+
+# Set ownership.
+RUN chown -R ducky-runner:ducky-runner /opt/Ducky-$VERSION/
 
 # Change user, set the working dir.
 USER ducky-runner
-WORKDIR /opt/Ducky/bin/
+WORKDIR /opt/Ducky-$VERSION/bin/
 
-# Enter the app.
-ENTRYPOINT ["/bin/Ducky"]
+# Enter the app. Not using ENTRYPOINT, as we don't use any startup flags rn...Or do we? :eyes:
 CMD ["./Ducky"]
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,18 @@ FROM debian:buster-slim
 # Sets the email.
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 
-# Create an arg for the version.
+# Create an arg for the version. --build-arg
 ARG version
+
+# Java version.
+# For Java 11: javaversion=adoptopenjdk-11-hotspot
+# For Java 16: javaversion=adoptopenjdk-16-hotspot
+
+ARG javaversion
 
 # Set version
 ENV BUILDVER=$version
+ENV JAVAVER=$javaversion
 
 # Install Java 11 (optionally will 16), and nano.
 RUN apt-get update && \
@@ -20,7 +27,7 @@ RUN apt-get update && \
     mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
     apt-get update && \
-    apt-get install adoptopenjdk-11-hotspot -y && \
+    apt-get install $JAVAVER -y && \
     apt-get install nano -y && \
     apt-get autoremove --purge -y && \
     rm -rv /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM debian:buster
+
+MAINTAINER Simon <email.todo>
+
+RUN apt-get install -y wget apt-transport-https gnupg && \
+    wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
+    gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public && \
+    gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg && \
+    rm adoptopenjdk-keyring.gpg && \
+    mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
+    apt-get update && \
+    apt-get install adoptopenjdk-11-hotspot && \
+    apt-get autoremove --purge -y && \
+    rm -rv /var/lib/apt/lists/* && \
+    useradd --no-log-init --shell /bin/false --no-create-home ducky-runner
+
+ADD Ducky-*.tar /opt/
+RUN chown -R ducky-runner:ducky-runner /opt/Ducky-*.tar && \
+    tar -xfz Ducky-*.tar > Ducky
+
+USER ducky-runner
+WORKDIR /opt/Ducky/
+
+
+ENTRYPOINT ["/bin/Ducky"]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using Debian 10.
-FROM debian:buster-slim
+FROM openjdk:18-jdk-alpine3.13
 
 # Sets the email.
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
@@ -8,32 +8,11 @@ LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 # At the time of writing this: version=1.6.4
 ARG version
 
-# Java version.
-# For Java 11: javaversion=adoptopenjdk-11-hotspot
-# For Java 16: javaversion=adoptopenjdk-16-hotspot
-ARG javaversion
-
 # Set version
 ENV BUILDVER=$version
-ENV JAVAVER=$javaversion
-
-# Install Java, and nano.
-RUN apt-get update && \
-    apt-get install -y wget apt-transport-https gnupg && \
-    wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \
-    gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --import public && \
-    gpg --no-default-keyring --keyring ./adoptopenjdk-keyring.gpg --export --output adoptopenjdk-archive-keyring.gpg && \
-    rm adoptopenjdk-keyring.gpg && \
-    mv adoptopenjdk-archive-keyring.gpg /usr/share/keyrings && chown root:root /usr/share/keyrings/adoptopenjdk-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/adoptopenjdk-archive-keyring.gpg] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb buster main" | tee /etc/apt/sources.list.d/adoptopenjdk.list && \
-    apt-get update && \
-    apt-get install $JAVAVER -y && \
-    apt-get install nano -y && \
-    apt-get autoremove --purge -y && \
-    rm -rv /var/lib/apt/lists/*
 
 # Add the user we're going to run as.
-RUN useradd --no-log-init --shell /bin/false --no-create-home ducky-runner
+RUN adduser --no-log-init --shell /bin/false --no-create-home ducky-runner
 
 # Add Ducky-<release>.tar from the host working Directory to /opt/ in the container.
 COPY Ducky-$BUILDVER.tar /opt/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,19 +5,19 @@ FROM debian:buster-slim
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 
 # Create an arg for the version. --build-arg
+# At the time of writing this: version=1.6.4
 ARG version
 
 # Java version.
 # For Java 11: javaversion=adoptopenjdk-11-hotspot
 # For Java 16: javaversion=adoptopenjdk-16-hotspot
-
 ARG javaversion
 
 # Set version
 ENV BUILDVER=$version
 ENV JAVAVER=$javaversion
 
-# Install Java 11 (optionally will 16), and nano.
+# Install Java, and nano.
 RUN apt-get update && \
     apt-get install -y wget apt-transport-https gnupg && \
     wget https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:buster-slim
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"
 
 # Set version
-ENV VERSION 1.6.3
+ENV VERSION 1.6.4
 
 # Install Java 11 (optionally will 16), and nano.
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Using Debian 10.
+# Using Alpine, and Java 18
 FROM openjdk:18-jdk-alpine3.13
 
 # Sets the email.
@@ -28,5 +28,5 @@ RUN chown -R ducky-runner:ducky-runner /opt/Ducky-$BUILDVER/
 USER ducky-runner
 WORKDIR /opt/Ducky-$BUILDVER/bin/
 
-# Enter the app. Not using ENTRYPOINT, as we don't use any startup flags rn...Or do we? :eyes:
+# Enter the app.
 CMD ["./Ducky"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Using Debian 10.
-FROM debian:buster
+FROM debian:buster-slim
 
 # Sets the email.
 LABEL maintainer="67807644+KoxSosen@users.noreply.github.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG version
 ENV BUILDVER=$version
 
 # Add the user we're going to run as.
-RUN adduser --no-log-init --shell /bin/false --no-create-home ducky-runner
+RUN adduser -D -H ducky-runner
 
 # Add Ducky-<release>.tar from the host working Directory to /opt/ in the container.
 COPY Ducky-$BUILDVER.tar /opt/

--- a/build.gradle
+++ b/build.gradle
@@ -33,12 +33,12 @@ dependencies {
     implementation 'de.btobastian.sdcf4j:sdcf4j-javacord:1.0.10'
     implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
     implementation 'com.lmax:disruptor:3.4.4'
-    implementation 'org.jsoup:jsoup:1.14.2'
+    implementation 'org.jsoup:jsoup:1.14.3'
     implementation 'org.json:json:20210307'
 }
 
 group = 'com.github.koxsosen'
-version = '1.6.3'
+version = '1.6.4'
 description = 'Ducky'
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 
 application {
     mainClass = 'com.github.koxsosen.Main'
+    applicationDefaultJvmArgs = ['-Xms1G', '-Xmx1G', '-XX:+UseG1GC', '-XX:G1HeapRegionSize=4M', '-XX:+UnlockExperimentalVMOptions', '-XX:+ParallelRefProcEnabled', '-XX:+AlwaysPreTouch', '-XX:MaxInlineLevel=15', '-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector']
 }
 
 repositories {

--- a/src/main/java/com/github/koxsosen/Main.java
+++ b/src/main/java/com/github/koxsosen/Main.java
@@ -65,7 +65,7 @@ public class Main {
                 .login().join();
                 // If the bot disconnects always reconnect with a 2*sec delay. ( 1st: 2s, 2nd:4s )
                 api.setReconnectDelay(attempt -> attempt * 2);
-                // Only cache 10 messages per channel & remove ones older than 30 min.
+                // Only cache 10 messages per channel & remove ones older than 15 min.
                 api.setMessageCacheSize(10, 30*30);
         // Set the bots status
         api.updateActivity(ActivityType.valueOf(Constants.STATUSTYPE), Constants.STATUS());


### PR DESCRIPTION
This PR implements Docker support for Ducky, or in other worlds, it "Dockerizes" Ducky. 

Checklist

- [x] Make it actually work.
- [x] Install Java 11
- [x] Add email
- [x] Add JVM flags to the script.
- [x] Maybe add enviroment variables.


General concept:
- You build using your Ducky-<ver>.zip, and the image will take care of the rest.


Fixes #18 
Marked as Draf; This hasn't been tested yet, and it isn't production ready.